### PR TITLE
Changes to integrate Ramulator with the Structural Simulation Toolkit…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ endif
 ramulator: $(MAIN) $(OBJS) $(SRCDIR)/*.h | depend
 	$(CXX) $(CXXFLAGS) -DRAMULATOR -o $@ $(MAIN) $(OBJS)
 
+libramulator.a: $(OBJS) $(OBJDIR)/Gem5Wrapper.o
+	libtool -static -o $@ $(OBJS) $(OBJDIR)/Gem5Wrapper.o
+
 $(OBJS): | $(OBJDIR)
 
 $(OBJDIR): 

--- a/src/MemoryFactory.cpp
+++ b/src/MemoryFactory.cpp
@@ -67,3 +67,14 @@ MemoryBase *MemoryFactory<SALP>::create(const Config& configs, int cacheline) {
 }
 
 }
+
+// This function can be used by autoconf AC_CHECK_LIB since
+// apparently it can't detect C++ functions.
+// Basically just an entry in the symbol table
+extern "C"
+{
+    void libramulator_is_present(void)
+    {
+        ;
+    }
+}


### PR DESCRIPTION
Hello, I'd like to integrate Ramulator with the Structural Simulation Toolkit (SST). 

The SST (https://github.com/sstsimulator/sst-elements  and http://sst-simulator.org/) is a modular processor, network, and memory simulator focused on HPC architectures. We currently support some simple 'homegrown' memory models, DRAMSim, and the Goblin HMC simulator. We'd like to add Ramulator as another memory backend. 

The changes required to Ramulator are pretty minimal:
  1) Add two lines to the Makefile to allow building as a library
  2) Add a 'dummy' function to MemoryFactory.cc 

Change (2) isn't strictly necessary, but will make it easier for our autotools configure to detect that the right version of Ramulator is installed. 

Thanks!