### PR TITLE
DDR4: Honour ACT->REF distance.

### DIFF
--- a/src/DDR4.cpp
+++ b/src/DDR4.cpp
@@ -323,6 +323,7 @@ void DDR4::init_timing()
     t[int(Command::PREA)].push_back({Command::ACT, 1, s.nRP});
 
     // RAS <-> REF
+    t[int(Command::ACT)].push_back({Command::REF, 1, s.nRC});
     t[int(Command::PRE)].push_back({Command::REF, 1, s.nRP});
     t[int(Command::PREA)].push_back({Command::REF, 1, s.nRP});
     t[int(Command::RDA)].push_back({Command::REF, 1, s.nRTP + s.nRP});


### PR DESCRIPTION
This is a safeguard when e.g. the following sequence of commands occurs
with minimal distance:
ACT(x), RDA(x), REF

In this case RDA will be issued as early as possible for minimum data arrival
delay, but not finish until after tRC. The existing distance between RDA and
REF is insufficient to guarantee compliant timing, as generally nRAS > nRTP+nRP.
This patch adds a minimal distance between ACT and REF, mirroring the ACT-ACT
distance at the bank level.