### PR TITLE
fix deadlock on write queue; add write callback; fix namespace

### DIFF
--- a/src/Controller.h
+++ b/src/Controller.h
@@ -356,10 +356,7 @@ public:
         /*** 3. Should we schedule writes? ***/
         if (!write_mode) {
             // yes -- write queue is almost full or read queue is empty
-            if (writeq.size() > int(wr_high_watermark * writeq.max) 
-                    /*|| readq.size() == 0*/) // Hasan: Switching to write mode when there are just a few 
-                                              // write requests, even if the read queue is empty, incurs a lot of overhead. 
-                                              // Commented out the read request queue empty condition
+            if (writeq.size() > int(wr_high_watermark * writeq.max) || readq.size() == 0)
                 write_mode = true;
         }
         else {
@@ -452,6 +449,7 @@ public:
 
         if (req->type == Request::Type::WRITE) {
             channel->update_serving_requests(req->addr_vec.data(), -1, clk);
+            req->callback(*req);
         }
 
         // remove request from queue

--- a/src/Refresh.h
+++ b/src/Refresh.h
@@ -26,7 +26,6 @@
 #include "ALDRAM.h"
 
 using namespace std;
-using namespace ramulator;
 
 namespace ramulator {
 


### PR DESCRIPTION
This fixes 3 issues, 1 major and 2 minor.

1) The write queue by default waits to be 80% full before issuing requests even with no outstanding read requests. This is a serious problem for simulating architectures that use load-store streaming patterns. A read stream will back pressure when the memory controllers write queues are full; this halts further progress as no more reads can be issued. Further writes required to fill ramulator's queue cannot be issued because they are dependent on the stalled load streams, causing deadlock. The simple solution is to force writes when there are no reads waiting.

2) Add a callback when writes complete; this is obviously necessary for simulating any architecture that enforces trivial memory ordering guarantees.

3) This extraneous namespace is causing all of the ramulator namespace guards to have no effect when integrating with outside projects.