### PR TITLE
Example of a debug flag

### DIFF
--- a/configs/DDR3-test.cfg
+++ b/configs/DDR3-test.cfg
@@ -1,0 +1,32 @@
+########################
+# Example config file
+# Comments start with #
+# There are restrictions for valid channel/rank numbers
+ standard = DDR3
+ channels = 1
+ ranks = 1
+ speed = DDR3_1600K
+ org = DDR3_2Gb_x8
+# record_cmd_trace: (default is off): on, off
+ record_cmd_trace = off
+# print_cmd_trace: (default is off): on, off
+ print_cmd_trace = off
+
+### Below are parameters only for CPU trace
+ cpu_tick = 4
+ mem_tick = 1
+### Below are parameters only for multicore mode
+# When early_exit is on, all cores will be terminated when the earliest one finishes.
+ early_exit = on
+# early_exit = on, off (default value is on)
+# If expected_limit_insts is set, some per-core statistics will be recorded when this limit (or the end of the whole trace if it's shorter than specified limit) is reached. The simulation won't stop and will roll back automatically until the last one reaches the limit.
+ expected_limit_insts = 200000000
+ warmup_insts = 100000000
+ cache = no
+# cache = no, L1L2, L3, all (default value is no)
+ translation = None
+# translation = None, Random (default value is None)
+#
+debugflags = test_flag
+
+########################

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -1,0 +1,13 @@
+#ifndef __DEBUG_H
+#define __DEBUG_H
+
+//turn DEBUG on or off at compile time
+#define DEBUG
+
+#ifdef DEBUG
+    #define DEBUG_MSG(flag, str) do { if(configs["debugflags"].find(flag) != std::string::npos){std::cout << flag <<": " << str << std::endl;} } while( false )
+#else
+    #define DEBUG_MSG(flag, str) do {} while(false)
+#endif   
+
+#endif /* __DEBUG_H */

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -4,6 +4,7 @@
 #include "SpeedyController.h"
 #include "Memory.h"
 #include "DRAM.h"
+#include "Debug.h"
 #include "Statistics.h"
 #include <cstdio>
 #include <cstdlib>
@@ -184,6 +185,7 @@ int main(int argc, const char *argv[])
     }
 
     Config configs(argv[1]);
+    DEBUG_MSG("test_flag", "test_msg");
 
     const std::string& standard = configs["standard"];
     assert(standard != "" || "DRAM standard should be specified.");


### PR DESCRIPTION
Example on how to print things only when a certain debug flag is specified.
The current implementation is not very efficient,
 as there is a call each time to check the config class whether a string contains a substring.
Debug can be turned off by not defining DEBUG.
A good suggestion would be to make a new make target 'debug'
so the compiler turns DEBUG on or off based on compilation flags.
Another suggestion is to make the DEBUG flag printing more efficient.