### PR TITLE
Ddr3 timing fixes

### DIFF
--- a/src/DDR3.cpp
+++ b/src/DDR3.cpp
@@ -300,6 +300,8 @@ void DDR3::init_timing()
     t[int(Command::ACT)].push_back({Command::REF, 1, s.nRC});
     t[int(Command::PRE)].push_back({Command::REF, 1, s.nRP});
     t[int(Command::PREA)].push_back({Command::REF, 1, s.nRP});
+    t[int(Command::RDA)].push_back({Command::REF, 1, s.nRTP + s.nRP});
+    t[int(Command::WRA)].push_back({Command::REF, 1, s.nCWL + s.nBL + s.nWR + s.nRP});
     t[int(Command::REF)].push_back({Command::ACT, 1, s.nRFC});
 
     // RAS <-> PD

--- a/src/DDR3.cpp
+++ b/src/DDR3.cpp
@@ -297,6 +297,7 @@ void DDR3::init_timing()
     t[int(Command::PREA)].push_back({Command::ACT, 1, s.nRP});
 
     // RAS <-> REF
+    t[int(Command::ACT)].push_back({Command::REF, 1, s.nRC});
     t[int(Command::PRE)].push_back({Command::REF, 1, s.nRP});
     t[int(Command::PREA)].push_back({Command::REF, 1, s.nRP});
     t[int(Command::REF)].push_back({Command::ACT, 1, s.nRFC});


### PR DESCRIPTION
I finally got round to back-porting my earlier DDR4 timing fixes to the DDR3 timing model. It might be worthwhile to check the LPDDR3/4 and GDDR5 timing models as well, but I am insufficiently up to speed on their subtleties to propose such changes at this point.