### PR TITLE
fixed DDR4 timing bug?

### DIFF
--- a/src/DDR4.cpp
+++ b/src/DDR4.cpp
@@ -292,10 +292,10 @@ void DDR4::init_timing()
     t[int(Command::RD)].push_back({Command::WRA, 1, s.nBL + s.nRTRS, true});
     t[int(Command::RDA)].push_back({Command::WR, 1, s.nBL + s.nRTRS, true});
     t[int(Command::RDA)].push_back({Command::WRA, 1, s.nBL + s.nRTRS, true});
-    t[int(Command::RD)].push_back({Command::WR, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
-    t[int(Command::RD)].push_back({Command::WRA, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
-    t[int(Command::RDA)].push_back({Command::WR, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
-    t[int(Command::RDA)].push_back({Command::WRA, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
+    t[int(Command::WR)].push_back({Command::WR, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
+    t[int(Command::WR)].push_back({Command::WRA, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
+    t[int(Command::WRA)].push_back({Command::WR, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
+    t[int(Command::WRA)].push_back({Command::WRA, 1, s.nCL + s.nBL + s.nRTRS - s.nCWL, true});
     t[int(Command::WR)].push_back({Command::RD, 1, s.nCWL + s.nBL + s.nRTRS - s.nCL, true});
     t[int(Command::WR)].push_back({Command::RDA, 1, s.nCWL + s.nBL + s.nRTRS - s.nCL, true});
     t[int(Command::WRA)].push_back({Command::RD, 1, s.nCWL + s.nBL + s.nRTRS - s.nCL, true});


### PR DESCRIPTION
Apologies if this has already been addressed in #47 but the source still seems incorrect. Lines 291-294 seem redundant / incompatible with lines 295-298 and wr-wr timings for sibling banks seem to be missing. 

If this is not a mistake, could you please explain how these timings correspond to the JEDEC standards or any DDR4 catalog from Micron, etc. (page number, timing name in the standard)?

Thank you!
Helena